### PR TITLE
feat(graphql): Deleting data with Prisma

### DIFF
--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -8,6 +8,7 @@ export const typeDefs = gql`
   type Mutation {
     postCreate(post: PostInput!): PostPayload!
     postUpdate(postId: ID!, post: PostInput!): PostPayload!
+    postDelete(postId: ID!): PostPayload!
   }
 
   type Post {

--- a/src/resolvers/Mutation.ts
+++ b/src/resolvers/Mutation.ts
@@ -91,4 +91,33 @@ export const Mutation = {
       }),
     };
   },
+  postDelete: async (
+    parent: any,
+    { postId }: { postId: string },
+    { prisma }: Context
+  ): Promise<PostPayloadType> => {
+    const post = await prisma.post.findUnique({
+      where: {
+        id: +postId,
+      },
+    });
+
+    if (!post) {
+      return {
+        userErrors: [{ message: "Post does not exist" }],
+        post: null,
+      };
+    }
+
+    await prisma.post.delete({
+      where: {
+        id: +postId,
+      },
+    });
+
+    return {
+      userErrors: [],
+      post,
+    };
+  },
 };


### PR DESCRIPTION
# What are changes?
- Add `postDelete` mutation
- Add ability to delete post